### PR TITLE
zu.stringToInteger()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-01-18
+
+### Changed
+
+- `zu.stringToInt` has been renamed to `zu.stringToInteger` and now uses `zu.integer()`
+to produces the final forward type: `Integer`.
+
 ## [0.15.0] - 2026-01-18
 
 ### Added
@@ -171,6 +178,7 @@ publication didn't succeed completely. This is a re-release.
 
 - First iteration of the library. It has JSON parsing utilities.
 
+[0.16.0]: https://github.com/infra-blocks/ts-zod-utils/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/infra-blocks/ts-zod-utils/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/infra-blocks/ts-zod-utils/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/infra-blocks/ts-zod-utils/compare/v0.12.0...v0.13.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { integer } from "./integer.js";
 import { iso } from "./iso/index.js";
 import { json } from "./json/index.js";
 import { string } from "./string/index.js";
+import type { IntegerString } from "./string/integer.js";
 
 const csvSchema = z.string().transform((str) => str.split(","));
 
@@ -18,20 +19,24 @@ function csv() {
   return csvSchema;
 }
 
-const stringToIntCodec = z.codec(z.string().regex(z.regexes.integer), z.int(), {
+const stringToIntegerCodec = z.codec(string.integer(), integer(), {
   decode: (str) => Number.parseInt(str, 10),
-  encode: (num) => num.toString(),
+  encode: (num) => num.toString() as IntegerString,
 });
 
 /**
- * A string to integer codec, as defined in Zod's documentation.
+ * A string to integer codec.
  *
- * @returns A string to int codec.
+ * Same as defined in Zod's documentation, except branding is included using
+ * {@link zu.integer} in place of {@link z.int} and {@link zu.string.integer}
+ * in place of `z.string().regex(z.regexes.integer)`.
+ *
+ * @returns A string to integer codec.
  *
  * @see https://zod.dev/codecs#stringtoint
  */
-function stringtoInt() {
-  return stringToIntCodec;
+function stringtoInteger() {
+  return stringToIntegerCodec;
 }
 
 const stringToURLCodec = z.codec(z.url(), z.instanceof(URL), {
@@ -99,7 +104,7 @@ const zu = {
   csv,
   isValid,
   integer,
-  stringtoInt,
+  stringtoInteger,
   stringToUrl,
   typeGuard,
 };

--- a/test/unit/lib.ts
+++ b/test/unit/lib.ts
@@ -1,0 +1,8 @@
+import { expect } from "@infra-blocks/test";
+import type { z } from "zod";
+
+export function expectSchemaThrow<S extends z.ZodType>(schema: S) {
+  return (value: unknown) => {
+    expect(() => schema.parse(value)).to.throw();
+  };
+}

--- a/test/unit/string/integer.ts
+++ b/test/unit/string/integer.ts
@@ -1,14 +1,14 @@
 import { expect, expectTypeOf } from "@infra-blocks/test";
 import { zu } from "../../../src/index.js";
 import type { IntegerString } from "../../../src/string/integer.js";
+import { expectSchemaThrow } from "../lib.js";
 
 export function injectIntegerTests() {
-  function expectThrow(value: unknown) {
-    expect(() => zu.string.integer().parse(value)).to.throw();
-  }
+  const schema = zu.string.integer();
+  const expectThrow = expectSchemaThrow(schema);
 
   function expectEquals(value: string) {
-    const result = zu.string.integer().parse(value);
+    const result = schema.parse(value);
     expectTypeOf(result).toEqualTypeOf<IntegerString>();
     expect(result).to.equal(value);
   }


### PR DESCRIPTION
- Renamed from zu.stringToInt.
- Now uses zu.integer() as the output schema
